### PR TITLE
Add handling for AltGr sequences

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -270,10 +270,16 @@ func (p *Prompt) feed(buf []byte) (shouldExit bool, exec *Exec, bufLeft []byte, 
 		if p.handleASCIICodeBinding(b) {
 			return
 		}
+		i := 0
+		r, _ := utf8.DecodeRune(b[i:])
+		// AltGr key handling: expect ESC (0x1b) followed by Unicode character; skip ESC
+		if r == 0x1b {
+			i = 1
+			r, _ = utf8.DecodeRune(b[i:])
+		}
 		// Only insert printable characters
-		r, _ := utf8.DecodeRune(b)
 		if strconv.IsPrint(r) {
-			p.buf.InsertText(string(b), false, true)
+			p.buf.InsertText(string(b[i:]), false, true)
 		}
 	}
 

--- a/prompt.go
+++ b/prompt.go
@@ -270,21 +270,25 @@ func (p *Prompt) feed(buf []byte) (shouldExit bool, exec *Exec, bufLeft []byte, 
 		if p.handleASCIICodeBinding(b) {
 			return
 		}
-		i := 0
-		r, _ := utf8.DecodeRune(b[i:])
-		// AltGr key handling: expect ESC (0x1b) followed by Unicode character; skip ESC
-		if r == 0x1b {
-			i = 1
-			r, _ = utf8.DecodeRune(b[i:])
-		}
+		r, _ := nextRuneSkippingLeadingEsc(b)
 		// Only insert printable characters
-		if strconv.IsPrint(r) {
-			p.buf.InsertText(string(b[i:]), false, true)
+		if r != utf8.RuneError && strconv.IsPrint(r) {
+			p.buf.InsertText(string(r), false, true)
 		}
 	}
 
 	shouldExit = p.handleKeyBinding(key)
 	return
+}
+
+// nextRuneSkippingLeadingEsc returns the next rune from the b skipping any leading ESC. This is mainly intended
+// for Windows AltGr key handling where b contains ESC (0x1b) is followed by a Unicode character.
+func nextRuneSkippingLeadingEsc(b []byte) (r rune, size int) {
+	r, size = utf8.DecodeRune(b)
+	if r == 0x1b {
+		r, size = utf8.DecodeRune(b[size:])
+	}
+	return r, size
 }
 
 func (p *Prompt) handleCompletionKeyBinding(key Key, completing bool) {


### PR DESCRIPTION
For AltGr keys on Windows go-tty returns ESC plus the character (e.g. ESC @). When processing returns to this level, the NotDefined block handles "normal" keys, but throws out the AltGr escape sequence because the ESC is not printable.

Instead, these changes skip over the leading ESC key and then returns to normal processing; check if the character is printable and if so insert it into the buffer.